### PR TITLE
TRPL2ビルド用Dockerイメージのアップデート

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,6 @@
-FROM buildpack-deps:stretch
+FROM rust:1.47.0
 
-ENV RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    RUST_VERSION=1.28.0 \
-    RUST_ARCH=x86_64-unknown-linux-gnu \
-    RUSTUP_VERSION=1.13.0 \
-    MDBOOK_VERSION=0.1.7 \
-    PATH=/usr/local/cargo/bin:$PATH
+ENV MDBOOK_VERSION=0.1.8
 
 # Install CircleCI requirements
 RUN set -eux; \
@@ -14,27 +8,13 @@ RUN set -eux; \
     DEBIAN_FRONTEND=noninteractive apt-get install -yy git openssh-server tar gzip ca-certificates; \
     rm -rf /var/lib/apt/lists/*;
 
-# Install Rust Toolchain
+# Install mdBook and sd
 RUN set -eux; \
-    rustupSha256='f69dafcca62fe70d7882113e21bb96a2cbdf4fc4636d25337d6de9191bdec8da'; \
-    url="https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUST_ARCH}/rustup-init"; \
-    wget "$url"; \
-    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
-    chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION; \
-    rm rustup-init; \
-    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
-    rustup --version; \
+    cargo install --force mdbook --vers "^$MDBOOK_VERSION"; \
+    cargo install --force sd; \
     rustc --version; \
-    cargo --version;
-
-# If you are builing this image in China mainland, uncomment this.
-# COPY ./cargo-config-cn /root/.cargo/config
-
-# Install mdBook
-RUN set -eux; \
-    cargo install --force --root $CARGO_HOME mdbook --vers "^$MDBOOK_VERSION"; \
     mdbook --version; \
-    rm -rf $CARGO_HOME/git;
+    sd --version; \
+    rm -rf $CARGO_HOME/git $CARGO_HOME/registry;
 
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
- Rustを1.28.0から1.47.0へアップグレード
- mdBookを0.1.7から0.1.8へアップグレード
- `sd`コマンドを追加（最新バージョン）

Fixes: #1 