### PR TITLE
最新の Edition Guide のビルド環境に合わせてバージョンアップ

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,10 +4,10 @@ ARG MDBOOK_VERSION="0.4.13"
 ARG MDBOOK_TRANSCHECK_VERSION="0.2.8"
 
 # Install mdBook
-RUN cargo install mdbook --vers ${MDBOOK_VERSION}
+RUN cargo install mdbook --locked --vers ${MDBOOK_VERSION}
 
 # Install mdbook-transcheck
-RUN cargo install mdbook-transcheck --vers ${MDBOOK_TRANSCHECK_VERSION}
+RUN cargo install mdbook-transcheck --locked --vers ${MDBOOK_TRANSCHECK_VERSION}
 
 # Install CircleCI Requirements
 # https://circleci.com/docs/2.0/custom-images/#required-tools-for-primary-containers

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
-FROM rust:1.56.1-slim
+FROM rustlang/rust:nightly-slim
 
-ARG MDBOOK_VERSION="0.4.13"
+ARG MDBOOK_VERSION="0.4.43"
 ARG MDBOOK_TRANSCHECK_VERSION="0.2.8"
 
 # Install mdBook


### PR DESCRIPTION
rust-lang-ja/edition-guide#119 の解決策です。

[本家リポジトリ](https://github.com/rust-lang/edition-guide/blob/master/.github/workflows/main.yml#L19-L21) に合わせて nightly 版 Rust を使うという方針です。
手元で Docker を立てて、 `mdbook test` が成功することは確認しています。